### PR TITLE
Support Ruby 3

### DIFF
--- a/lib/like/hooks.rb
+++ b/lib/like/hooks.rb
@@ -32,9 +32,8 @@ module Like::Hooks
     def view_layouts_base_content(context={})
       request = context[:request]
       if context[:controller].controller_name == 'wiki' && context[:controller].action_name == 'show' then
-        wiki_title = URI.decode(request.path.split("/").last)
-        str = URI.decode(request.path.split("/projects/").last)
-        identifier = str.split("/wiki/").first
+        wiki_title = URI.decode_www_form(request.path.split("/").last)
+        identifier = context[:project].identifier
         wiki_pages = WikiPage.where(title: wiki_title)
         for wiki_page in wiki_pages do
           if wiki_page.project.identifier == identifier then


### PR DESCRIPTION
I replaced `URI.decode` with `URI.decode_www_form`.
And I replaced the process of obtaining the identifier.
It works fine in my environment, can you please check?

My Redmine environment is as follows.
```
Environment:
  Redmine version                5.1.0
  Ruby version                   3.1.4-p223 (2023-03-30) [x64-mingw-ucrt]
  Rails version                  6.1.7.6
```